### PR TITLE
Specified dependencies in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@ At first it was meant to be only for tar archives (hence the name),
 but support for other archives does not hurt. 
 Dependencies are:
 
-    * libarchive
+    * libarchive-dev
+    * python-libarchive
     * Python 2.7 (or Python 2.6)
 
 


### PR DESCRIPTION
I really like this project, though it gave a me a bit of a hiccup just starting it up.  It seems when the user doesn't have the `libarchive-dev` package installed, the "-larchive" and "-l:libarchive.so.13.1.2" (looks like Ubuntu releases) linkers are missing, so the compilation fails.
