### PR TITLE
Backwards and shift-arrow navigation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Key bindings
 ============
 
 Key bindings are listed in HELP window,
-you can access it by pressing *h* or *?* key.
+you can access it by pressing the *?* key.
 
 {help_string}
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 0.1.4 (unreleased)
 ------------------
 
+- Added backwards (from init dir) and shift-arrow navigation
+  [Shaun Marshall]
 - Refactor unicode support for lower level functions.
   [Matej Cotman]
 - Fixed Hydra build error.

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -11,6 +11,8 @@ Changelog
   [Matej Cotman]
 - Logging to ~/.tarman.log
   [Matej Cotman]
+- Added view toggle for hidden files/subdirectories
+  [Shaun Marshall]
 
 
 0.1.2 (2013-08-13)

--- a/src/tarman/__init__.py
+++ b/src/tarman/__init__.py
@@ -341,12 +341,12 @@ class Main(object):
 
                 TextWin(self).show("Extracted to:\n{0}".format(s))
 
-            elif self.ch in [ord('?'), curses.KEY_F1, ord('h')]:
+            elif self.ch in [ord('?'), curses.KEY_F1]:
                 curses.curs_set(0)
                 textwin = TextWin(self)
                 textwin.show(HELP_STRING)
 
-            if self.ch == ord('.'):
+            if self.ch == ord('h') :
                 if self.show_hiddens == True:
                     self.show_hiddens = False
                 else:

--- a/src/tarman/__init__.py
+++ b/src/tarman/__init__.py
@@ -52,7 +52,8 @@ class Main(object):
         self.area = None
         self.container = FileSystem()
         self.directory = self.container.abspath(directory)
-        self.checked = DirectoryTree(self.directory, self.container)
+        self.root_directory = '/'
+        self.checked = DirectoryTree(self.root_directory, self.container)
         self.show_hiddens = show_hiddens
         self.chdir(self.directory)
 
@@ -100,9 +101,6 @@ class Main(object):
 
     def chdir(self, newpath):
         if newpath is None:
-            return False
-
-        if not newpath.startswith(self.directory):
             return False
 
         try:
@@ -221,10 +219,10 @@ class Main(object):
             elif self.ch == curses.KEY_DOWN:
                 self.area.set_params(h, offset=1)
 
-            elif self.ch == curses.KEY_PPAGE:
+            elif self.ch in [curses.KEY_PPAGE, curses.KEY_SR]:
                 self.area.set_params(h, offset=-5)
 
-            elif self.ch == curses.KEY_NPAGE:
+            elif self.ch in [curses.KEY_NPAGE, curses.KEY_SF]:
                 self.area.set_params(h, offset=5)
 
             elif self.ch == 32:

--- a/src/tarman/constants.py
+++ b/src/tarman/constants.py
@@ -4,13 +4,13 @@ ITEMS_WARNING = 10000
 HELP_STRING = """Browser window key bindings:
   - c              - create archive from selected files
   - e              - extract selected files
-  - h/?/F1         - help window
+  - ?/F1           - help window
   - LEFT/BACKSPACE - go one directory up
   - q              - quit
   - RIGHT/ENTER    - go in to directory or archive
   - SPACE          - select and unselect files
   - UP/DOWN        - move up or down in browser
-  - .              - toggle show/hide hidden files (".*")
+  - h              - toggle show/hide hidden files (".*")
 
 Overlay window key bindings:
   - ENTER          - confirm/ok


### PR DESCRIPTION
Directory permissions cease the screen from populating each area, so there is not yet a conflict with that future implementation.  My keyboard (HP netbook) also doesn't have PageUp/PageDown, so I was looking at holding down shift to do the same thing.  Let me know what you think.
